### PR TITLE
http to https elevation in prod

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,6 +18,13 @@ app.use(cookieParser());
 // Serve up static assets (usually on heroku)
 if (process.env.NODE_ENV === 'production') {
   app.use(express.static('client/build'));
+  app.use((req, res, next) => {
+    if (req.header('x-forwarded-proto') !== 'https') {
+      res.redirect(`https://${req.header('host')}${req.url}`);
+    }
+    else
+      next();
+  })
 }
 
 app.use(routes);


### PR DESCRIPTION
Elevates all requests to https://.  If you explicitly type in http:// + url for the homepage without a slash (ie http://tripsyapp.herokuapp.com) it will still fail to log in